### PR TITLE
Sync pendant styles with StyleName enum

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,8 +23,14 @@ enum Emblem {
 }
 
 enum StyleName {
-  PROMPT4
+  DEJA
+  GATTI
+  JAIDA
+  JHON
+  JWAE
+  KING
   LEXY
+  NEIKO
 }
 
 enum GoldCombo {


### PR DESCRIPTION
## Summary
- extend the manage-styles CLI to update the Prisma StyleName enum based on the pendant JSON
- add validation to prevent duplicate enum values and write enum updates only when needed
- sync the schema to include all existing pendant styles

## Testing
- npx prisma validate *(fails: DATABASE_URL env var not set in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e98015088333bb61920a3a567c8d